### PR TITLE
A few changes...

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ GEM
     debug_inspector (0.0.3)
     erubi (1.7.0)
     execjs (2.7.0)
-    ffi (1.9.21)
+    ffi (1.9.18)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     i18n (0.9.5)

--- a/config/database.yml
+++ b/config/database.yml
@@ -11,15 +11,15 @@ default: &default
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: /opt/app-root/data/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: /opt/app-root/data/test.sqlite3
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: /opt/app-root/data/production.sqlite3

--- a/db/migrate/20160711185523_create_contacts.rb
+++ b/db/migrate/20160711185523_create_contacts.rb
@@ -1,4 +1,4 @@
-class CreateContacts < ActiveRecord::Migration
+class CreateContacts < ActiveRecord::Migration[5.1]
   def change
     create_table :contacts do |t|
       t.string :name


### PR DESCRIPTION
- Updated the ffi gem (apparently that version doesnt work anywhere...did some googling)
- added the version to the rails migration (new in Rails 5). This is so you can use the Ruby 2.4 image
- changed the directory of the sqllite database so you can map persistent storage to /opt/app-root/data